### PR TITLE
Fix inline warning on Linux (GCC 15)

### DIFF
--- a/bolt/bt_prelude.h
+++ b/bolt/bt_prelude.h
@@ -30,7 +30,7 @@ extern "C" {
 #define BT_NO_INLINE __declspec(noinline)
 #define BT_ASSUME(x) __assume(x)
 #else
-#define BT_FORCE_INLINE __attribute__((always_inline))
+#define BT_FORCE_INLINE __attribute__((always_inline)) inline
 #define BT_NO_INLINE
 #define BT_ASSUME(x) do { if (!(x)) __builtin_unreachable(); } while (0)
 #endif


### PR DESCRIPTION
warning: ‘always_inline’ function might not be inlinable unless also declared ‘inline’ [-Wattributes]