### PR TITLE
Fix minor typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ By default, Bolt sets up an environment that uses `malloc`/`realloc`/`free`, but
 Bolt also embeds my other library [picomatch](https://github.com/Beariish/picomatch) for regex parsing
 
 ## Minimal embedding example
-The [bolt-cli](https://github.com/Beariish/bolt/blob/main/bolt-cli/main.c) program provides a very consice example of how to embed bolt an an application, see the [Bolt embedding guide](https://github.com/Beariish/bolt/tree/main/doc/Bolt%20Embedding%20Guide.md) for more details.
+The [bolt-cli](https://github.com/Beariish/bolt/blob/main/bolt-cli/main.c) program provides a very concise example of how to embed bolt an an application, see the [Bolt embedding guide](https://github.com/Beariish/bolt/tree/main/doc/Bolt%20Embedding%20Guide.md) for more details.
 
 ## Language examples
 The [examples](https://github.com/Beariish/bolt/tree/main/examples) folder contains a few short examples of ideomatically written bolt code. Check out the [tests](https://github.com/Beariish/bolt/tree/main/tests) and [benchmarks](https://github.com/Beariish/bolt/tree/main/benchmarks) folders as wel for some more in-depth language overview.
@@ -80,5 +80,6 @@ Feature additions will need a lot of consideration, Bolt is very intentionally m
 
 ## License
 Bolt is licensed under MIT. See LICENSE for more information.
+
 
 

--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ Feature additions will need a lot of consideration, Bolt is very intentionally m
 
 ## License
 Bolt is licensed under MIT. See LICENSE for more information.
+

--- a/README.md
+++ b/README.md
@@ -80,6 +80,3 @@ Feature additions will need a lot of consideration, Bolt is very intentionally m
 
 ## License
 Bolt is licensed under MIT. See LICENSE for more information.
-
-
-

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ Bugfixes are likely to be accepted as long as they're within reason and don't ch
 
 Optimizations may also be accepted for minor versions under similar criteria. A before/after run of `/benchmarks/all` is expected to evaluate the impact and make sure nothing else regresses. If the specific optimization isn't captured in any existing benchmark, adding one is required.
 
-Feature additions will need a lot of consideration, Bolt is very intentionally minimal in its' design and featureset. I highly suggest you submit some kind of proposal or plan before starting any significant work on a feature to review. Use cases, performance, and implementation cost will all be expected to be justified.
+Feature additions will need a lot of consideration, Bolt is very intentionally minimal in its design and featureset. I highly suggest you submit some kind of proposal or plan before starting any significant work on a feature to review. Use cases, performance, and implementation cost will all be expected to be justified.
 
 ## License
 Bolt is licensed under MIT. See LICENSE for more information.
+
 

--- a/doc/Bolt Programming Guide.md
+++ b/doc/Bolt Programming Guide.md
@@ -1282,4 +1282,3 @@ The Bolt standard library contains a bunch of useful modules, though it's up to 
 ## 17. Learn more
 
 If you wish to learn more, I highly recommend you check out the Bolt [examples](https://github.com/Beariish/bolt/tree/main/examples), or even dive into the [benchmarks](https://github.com/Beariish/bolt/tree/main/benchmarks) or [tests](https://github.com/Beariish/bolt/tree/main/tests) to get a deeper understanding for the language. The rest of the documentation can be found [here](https://github.com/Beariish/bolt/tree/main/doc), as well.
-

--- a/doc/Bolt Programming Guide.md
+++ b/doc/Bolt Programming Guide.md
@@ -418,7 +418,7 @@ let b = a as bool // b: bool? = null
 let c = a as number! // a: number = 10, use ! to strip the null
 
 if let num = a as number {
-    // safe cast, we skip the branch is a is not a number
+    // safe cast, we skip the branch if a is not a number
 }
 ```
 
@@ -1282,3 +1282,4 @@ The Bolt standard library contains a bunch of useful modules, though it's up to 
 ## 17. Learn more
 
 If you wish to learn more, I highly recommend you check out the Bolt [examples](https://github.com/Beariish/bolt/tree/main/examples), or even dive into the [benchmarks](https://github.com/Beariish/bolt/tree/main/benchmarks) or [tests](https://github.com/Beariish/bolt/tree/main/tests) to get a deeper understanding for the language. The rest of the documentation can be found [here](https://github.com/Beariish/bolt/tree/main/doc), as well.
+


### PR DESCRIPTION
Just found these two typos in the documentation during reading.
~~Github thought it should also add the trailing newline, feel free to remove it, if you don't want that.~~