### PR TITLE
fix segfault on empty function body

### DIFF
--- a/bolt/bt_parser.c
+++ b/bolt/bt_parser.c
@@ -1395,7 +1395,8 @@ static bt_Type* infer_return(bt_Parser* parse, bt_Context* ctx, bt_AstBuffer* bo
     }
 
     if (level == 0 && !has_return && expected) {
-        uint16_t line, col = 0;
+        uint16_t line = 0;
+        uint16_t col = 0;
         
         if (body->length > 0) {
           line = body->elements[0]->source->line;


### PR DESCRIPTION
When parsing functions with empty function bodies such as 

```bolt
fn foo() : number {}
```

Bolt currently seg faults when trying to access element[0] in `bt_parser.c` line 1398. ideally this is avoided by using the function definition line instead of pulling from a potentially empty body.

I think you are considering rewriting the parser but this fix is quite simple.