### PR TITLE
Fix unresolved symbol

### DIFF
--- a/bolt/bt_userdata.c
+++ b/bolt/bt_userdata.c
@@ -27,6 +27,11 @@ static void push_userdata_field(bt_Context* ctx, bt_Type* type, const char* name
 	bt_buffer_push(ctx, fields, field);
 }
 
+void bt_userdata_type_push_field(bt_Context* ctx, bt_Type* type, const char* name, uint32_t offset, bt_Type* field_type, bt_UserdataFieldGetter getter, bt_UserdataFieldSetter setter)
+{
+	push_userdata_field(ctx, type, name, offset, field_type, getter, setter);
+}
+
 #define DEFINE_USERDATA_NUMBER_FIELD(fnname, dtype)                                                                \
 static bt_Value userdata_get_##fnname(bt_Context* ctx, uint8_t* userdata, uint32_t offset)                         \
 {																										           \


### PR DESCRIPTION
Fix unresolved symbol when using `bt_userdata_type_push_field`.